### PR TITLE
Update description.ru.yml (mistype in 100 EUR example)

### DIFF
--- a/modules/30-variables/15-variables-expressions/description.ru.yml
+++ b/modules/30-variables/15-variables-expressions/description.ru.yml
@@ -81,7 +81,7 @@ instructions: |
 
   <pre class='hexlet-basics-output'>
   125
-  7500
+  863.75
   </pre>
 
   Считаем, что:


### PR DESCRIPTION
Исправлена вторая строка в примере вывода для 100 евро (полагаю, здесь была допущена опечатка: код выводит 863.75, а в примере указано 7500).